### PR TITLE
fix: exit when handler not a stopper

### DIFF
--- a/go/http/service.go
+++ b/go/http/service.go
@@ -78,6 +78,8 @@ func (s *Service) Stop() {
 
 	if i, ok := s.f.(Stopper); ok {
 		s.done <- i.Stop(ctx)
+	} else {
+		s.done <- nil
 	}
 }
 


### PR DESCRIPTION
When the handler is not a `Stopper`, immediately exit.